### PR TITLE
feat: add pressable scale animations to drawer selectors

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -53,6 +53,7 @@
         "expo-linking": "~8.0.0",
         "expo-router": "~6.0.23",
         "expo-status-bar": "~3.0.0",
+        "pressto": "^0.6.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
         "react-native": "0.81.5",
@@ -1986,6 +1987,8 @@
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, ""],
 
     "presentable-error": ["presentable-error@0.0.1", "", {}, "sha512-E6rsNU1QNJgB3sjj7OANinGncFKuK+164sLXw1/CqBjj/EkXSoSdHCtWQGBNlREIGLnL7IEUEGa08YFVUbrhVg=="],
+
+    "pressto": ["pressto@0.6.1", "", { "peerDependencies": { "react": "*", "react-native": "*", "react-native-gesture-handler": "*", "react-native-reanimated": "*", "react-native-worklets": "*" } }, "sha512-tLYEzQTupHYTh556NSDbFc5FPF03g4AR98bYj1yEljKxBtZeMYw095zOUUAsFIuySBT6z7NKCjix6kMcCBxduw=="],
 
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 

--- a/example/package.json
+++ b/example/package.json
@@ -28,6 +28,7 @@
     "expo-linking": "~8.0.0",
     "expo-router": "~6.0.23",
     "expo-status-bar": "~3.0.0",
+    "pressto": "^0.6.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/example/src/components/panel/mobile-menu/eye-selector.tsx
+++ b/example/src/components/panel/mobile-menu/eye-selector.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { View, Pressable } from 'react-native';
+import { View } from 'react-native';
+import { PressableScale } from 'pressto';
 import Svg, { Path } from 'react-native-svg';
 import * as Burnt from '../../../utils/toast';
 import { useSelector } from '@legendapp/state/react';
@@ -35,7 +36,7 @@ export const EyeSelector = () => {
         const isSelected = shape === currentShape;
         const shapePath = getPathFromShape(shape, 16);
         return (
-          <Pressable
+          <PressableScale
             key={shape}
             onPress={() => handleSelect(shape)}
             style={[styles.shapeOption, isSelected && { backgroundColor: themeColor }]}
@@ -43,7 +44,7 @@ export const EyeSelector = () => {
             <Svg width={16} height={16} viewBox="0 0 16 16">
               <Path d={shapePath} fill={Colors.textPrimary} />
             </Svg>
-          </Pressable>
+          </PressableScale>
         );
       })}
     </View>

--- a/example/src/components/panel/mobile-menu/gap-selector.tsx
+++ b/example/src/components/panel/mobile-menu/gap-selector.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { View, Text } from 'react-native';
+import { PressableScale } from 'pressto';
 import * as Burnt from '../../../utils/toast';
 import { useSelector } from '@legendapp/state/react';
 import { qrcodeState$, GapSizes, type GapSize } from '../../../states';
@@ -27,7 +28,7 @@ export const GapSelector = () => {
       {GapSizes.map((size) => {
         const isSelected = size === currentGap;
         return (
-          <Pressable
+          <PressableScale
             key={size}
             onPress={() => handleSelect(size)}
             style={[
@@ -38,7 +39,7 @@ export const GapSelector = () => {
             <Text style={[styles.gapText, isSelected && styles.gapTextSelected]}>
               {size}
             </Text>
-          </Pressable>
+          </PressableScale>
         );
       })}
     </View>

--- a/example/src/components/panel/mobile-menu/logo-selector.tsx
+++ b/example/src/components/panel/mobile-menu/logo-selector.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { View, Text, Pressable } from 'react-native';
+import { View, Text } from 'react-native';
+import { PressableScale } from 'pressto';
 import * as Burnt from '../../../utils/toast';
 import { useSelector } from '@legendapp/state/react';
 import { qrcodeState$, LogoEmojis } from '../../../states';
@@ -27,13 +28,13 @@ export const LogoSelector = () => {
       {LogoEmojis.map((emoji, index) => {
         const isSelected = emoji === selectedLogo;
         return (
-          <Pressable
+          <PressableScale
             key={index}
             onPress={() => handleSelect(emoji)}
             style={[styles.logoOption, isSelected && { backgroundColor: themeColor }]}
           >
             <Text style={styles.logoEmoji}>{emoji || '—'}</Text>
-          </Pressable>
+          </PressableScale>
         );
       })}
     </View>

--- a/example/src/components/panel/mobile-menu/shape-selector.tsx
+++ b/example/src/components/panel/mobile-menu/shape-selector.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react';
-import { View, Pressable } from 'react-native';
+import { View } from 'react-native';
+import { PressableScale } from 'pressto';
 import Svg, { Path } from 'react-native-svg';
 import * as Burnt from '../../../utils/toast';
 import { useSelector } from '@legendapp/state/react';
@@ -35,7 +36,7 @@ export const ShapeSelector = () => {
         const isSelected = shape === currentShape;
         const shapePath = getPathFromShape(shape, 16);
         return (
-          <Pressable
+          <PressableScale
             key={shape}
             onPress={() => handleSelect(shape)}
             style={[styles.shapeOption, isSelected && { backgroundColor: themeColor }]}
@@ -43,7 +44,7 @@ export const ShapeSelector = () => {
             <Svg width={16} height={16} viewBox="0 0 16 16">
               <Path d={shapePath} fill={Colors.textPrimary} />
             </Svg>
-          </Pressable>
+          </PressableScale>
         );
       })}
     </View>

--- a/example/src/components/panel/mobile-menu/theme-selector.tsx
+++ b/example/src/components/panel/mobile-menu/theme-selector.tsx
@@ -1,6 +1,13 @@
-import React, { useCallback } from 'react';
-import { View, Pressable } from 'react-native';
+import React, { useCallback, useEffect } from 'react';
+import { View } from 'react-native';
+import { PressableScale } from 'pressto';
 import { LinearGradient } from 'expo-linear-gradient';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  interpolateColor,
+} from 'react-native-reanimated';
 import * as Burnt from '../../../utils/toast';
 import { useSelector } from '@legendapp/state/react';
 import { qrcodeState$ } from '../../../states';
@@ -9,6 +16,45 @@ import { styles } from './styles';
 
 const formatThemeName = (name: string) =>
   name.charAt(0).toUpperCase() + name.slice(1);
+
+const AnimatedPressableScale = Animated.createAnimatedComponent(PressableScale);
+
+interface ColorOptionProps {
+  themeName: ThemeName;
+  isSelected: boolean;
+  onPress: () => void;
+}
+
+const ColorOption = ({ themeName, isSelected, onPress }: ColorOptionProps) => {
+  const theme = Themes[themeName];
+  const progress = useSharedValue(isSelected ? 1 : 0);
+
+  useEffect(() => {
+    progress.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
+  }, [isSelected, progress]);
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    borderColor: interpolateColor(
+      progress.value,
+      [0, 1],
+      ['transparent', theme.colors[0]]
+    ),
+  }));
+
+  return (
+    <AnimatedPressableScale
+      onPress={onPress}
+      style={[styles.colorOption, animatedStyle]}
+    >
+      <LinearGradient
+        colors={[theme.colors[0], theme.colors[1]]}
+        start={{ x: 0, y: 0 }}
+        end={{ x: 1, y: 1 }}
+        style={styles.colorCircle}
+      />
+    </AnimatedPressableScale>
+  );
+};
 
 export const ThemeSelector = () => {
   const currentTheme = useSelector(qrcodeState$.currentTheme);
@@ -26,27 +72,14 @@ export const ThemeSelector = () => {
 
   return (
     <View style={styles.optionsRow}>
-      {(Object.keys(Themes) as ThemeName[]).map((themeName) => {
-        const theme = Themes[themeName];
-        const isSelected = themeName === currentTheme;
-        return (
-          <Pressable
-            key={themeName}
-            onPress={() => handleSelect(themeName)}
-            style={[
-              styles.colorOption,
-              isSelected && { borderColor: theme.colors[0] },
-            ]}
-          >
-            <LinearGradient
-              colors={[theme.colors[0], theme.colors[1]]}
-              start={{ x: 0, y: 0 }}
-              end={{ x: 1, y: 1 }}
-              style={styles.colorCircle}
-            />
-          </Pressable>
-        );
-      })}
+      {(Object.keys(Themes) as ThemeName[]).map((themeName) => (
+        <ColorOption
+          key={themeName}
+          themeName={themeName}
+          isSelected={themeName === currentTheme}
+          onPress={() => handleSelect(themeName)}
+        />
+      ))}
     </View>
   );
 };

--- a/example/src/components/panel/mobile-menu/theme-selector.tsx
+++ b/example/src/components/panel/mobile-menu/theme-selector.tsx
@@ -1,9 +1,9 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback } from 'react';
 import { View } from 'react-native';
 import { PressableScale } from 'pressto';
 import { LinearGradient } from 'expo-linear-gradient';
 import Animated, {
-  useSharedValue,
+  useDerivedValue,
   useAnimatedStyle,
   withTiming,
   interpolateColor,
@@ -27,11 +27,9 @@ interface ColorOptionProps {
 
 const ColorOption = ({ themeName, isSelected, onPress }: ColorOptionProps) => {
   const theme = Themes[themeName];
-  const progress = useSharedValue(isSelected ? 1 : 0);
-
-  useEffect(() => {
-    progress.value = withTiming(isSelected ? 1 : 0, { duration: 200 });
-  }, [isSelected, progress]);
+  const progress = useDerivedValue(() => {
+    return withTiming(isSelected ? 1 : 0, { duration: 200 });
+  }, [isSelected]);
 
   const animatedStyle = useAnimatedStyle(() => ({
     borderColor: interpolateColor(

--- a/example/src/hooks/use-responsive.ts
+++ b/example/src/hooks/use-responsive.ts
@@ -1,4 +1,4 @@
-import { useWindowDimensions, Platform } from 'react-native';
+import { useWindowDimensions } from 'react-native';
 
 const BREAKPOINTS = {
   // lg breakpoint - use compact layout below this
@@ -8,15 +8,10 @@ const BREAKPOINTS = {
 export const useResponsive = () => {
   const { width } = useWindowDimensions();
 
-  // On web, useWindowDimensions can return 0 on first render.
-  // Use a sensible default (desktop) to avoid layout flash.
-  const effectiveWidth =
-    Platform.OS === 'web' && width === 0 ? BREAKPOINTS.lg : width;
-
   return {
     // Use compact layout below lg breakpoint
-    isMobile: effectiveWidth < BREAKPOINTS.lg,
-    isDesktop: effectiveWidth >= BREAKPOINTS.lg,
-    width: effectiveWidth,
+    isMobile: width < BREAKPOINTS.lg,
+    isDesktop: width >= BREAKPOINTS.lg,
+    width,
   };
 };

--- a/example/src/hooks/use-responsive.ts
+++ b/example/src/hooks/use-responsive.ts
@@ -1,4 +1,4 @@
-import { useWindowDimensions } from 'react-native';
+import { useWindowDimensions, Platform } from 'react-native';
 
 const BREAKPOINTS = {
   // lg breakpoint - use compact layout below this
@@ -8,10 +8,14 @@ const BREAKPOINTS = {
 export const useResponsive = () => {
   const { width } = useWindowDimensions();
 
+  // On web, useWindowDimensions can return 0 on first render
+  const isReady = Platform.OS !== 'web' || width > 0;
+
   return {
     // Use compact layout below lg breakpoint
     isMobile: width < BREAKPOINTS.lg,
     isDesktop: width >= BREAKPOINTS.lg,
     width,
+    isReady,
   };
 };

--- a/example/src/hooks/use-responsive.ts
+++ b/example/src/hooks/use-responsive.ts
@@ -1,4 +1,4 @@
-import { useWindowDimensions } from 'react-native';
+import { useWindowDimensions, Platform } from 'react-native';
 
 const BREAKPOINTS = {
   // lg breakpoint - use compact layout below this
@@ -8,10 +8,15 @@ const BREAKPOINTS = {
 export const useResponsive = () => {
   const { width } = useWindowDimensions();
 
+  // On web, useWindowDimensions can return 0 on first render.
+  // Use a sensible default (desktop) to avoid layout flash.
+  const effectiveWidth =
+    Platform.OS === 'web' && width === 0 ? BREAKPOINTS.lg : width;
+
   return {
     // Use compact layout below lg breakpoint
-    isMobile: width < BREAKPOINTS.lg,
-    isDesktop: width >= BREAKPOINTS.lg,
-    width,
+    isMobile: effectiveWidth < BREAKPOINTS.lg,
+    isDesktop: effectiveWidth >= BREAKPOINTS.lg,
+    width: effectiveWidth,
   };
 };


### PR DESCRIPTION
## Summary
- Install pressto package for scale animations
- Replace `Pressable` with `PressableScale` in all mobile menu selectors
- Add animated border transition for theme color picker using `interpolateColor`

## Changes
- **theme-selector**: Animated border fade in/out when selecting colors
- **shape-selector**: PressableScale for tap feedback
- **eye-selector**: PressableScale for tap feedback
- **gap-selector**: PressableScale for tap feedback
- **logo-selector**: PressableScale for tap feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)